### PR TITLE
HW#08. kubernetes-monitor

### DIFF
--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -32,13 +32,15 @@ http {
     #gzip  on;
 
     server {
-        listen       8000;
+        listen       8080;
         server_name  localhost;
 
         #charset koi8-r;
 
         #access_log  logs/host.access.log  main;
-
+        location /basic_status {
+            stub_status;
+        }
         location / {
             root   /app;
             index  index.html index.htm;

--- a/kubernetes-monitoring/npe.deployment.yaml
+++ b/kubernetes-monitoring/npe.deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-prometheus-exporter
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-prometheus-exporter
+  template:
+    metadata:
+      labels:
+        app: nginx-prometheus-exporter
+    spec:
+      containers:
+        - name: example-app
+          image: enegu/otus-nginx:1.3
+          ports:
+          - name: web
+            containerPort: 8080
+        - name: nginx-prometheus-exporter
+          image: "nginx/nginx-prometheus-exporter:0.8.0"
+          imagePullPolicy: Always
+          args: ["-nginx.scrape-uri", "http://localhost:8080/basic_status"]
+          ports:
+            - containerPort: 9113
+              name: http

--- a/kubernetes-monitoring/npe.service.yaml
+++ b/kubernetes-monitoring/npe.service.yaml
@@ -1,0 +1,29 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-prometheus-exporter
+  labels:
+    app: nginx-prometheus-exporter
+spec:
+  selector:
+    app: nginx-prometheus-exporter
+  ports:
+  - name: webqq
+    port: 9113
+
+---
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: nginx-prometheus-exporter
+#   annotations:
+#     prometheus.io/scrape: 'true'
+#     prometheus.io/port:   '9113'
+# spec:
+#   ports:
+#     - name: http
+#       port: 80
+#       protocol: TCP
+#       targetPort: 9113
+#   selector:
+#     app: nginx-prometheus-exporter

--- a/kubernetes-monitoring/npe.servicemonitor.yaml
+++ b/kubernetes-monitoring/npe.servicemonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-prometheus-exporter
+  labels:
+    team: frontend
+spec:
+  selector:
+    matchLabels:
+      app: nginx-prometheus-exporter
+  endpoints:
+  - port: webqq

--- a/kubernetes-monitoring/prometheus.clusterrole.yaml
+++ b/kubernetes-monitoring/prometheus.clusterrole.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get"]
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]

--- a/kubernetes-monitoring/prometheus.clusterrolebinding.yaml
+++ b/kubernetes-monitoring/prometheus.clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default

--- a/kubernetes-monitoring/prometheus.prometheus.yaml
+++ b/kubernetes-monitoring/prometheus.prometheus.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  name: prometheus
+spec:
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      team: frontend
+  resources:
+    requests:
+      memory: 400Mi
+  enableAdminAPI: false

--- a/kubernetes-monitoring/prometheus.service.yaml
+++ b/kubernetes-monitoring/prometheus.service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30900
+    port: 9090
+    protocol: TCP
+    targetPort: web
+  selector:
+    prometheus: prometheus

--- a/kubernetes-monitoring/prometheus.serviceaccount.yaml
+++ b/kubernetes-monitoring/prometheus.serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus


### PR DESCRIPTION
# Выполнено ДЗ №8

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Создан кастомный образ NGINX, который отдает свои метрики по пути /basic_status - [док.](https://nginx.org/ru/docs/http/ngx_http_stub_status_module.html)
 - Развернут деплоймент NGINX с прикрученным nginx-prometheus-exporter. Создан сервис, через который доступны метрики в формате prometheus.
 - Развернут prometheus-operator - [док.](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md)
 - Развернут сервис Grafana [док.](https://grafana.com/docs/grafana/latest/setup-grafana/installation/kubernetes/)
 - Импортирован официальный дашборд NGINX - [тут](https://github.com/nginxinc/nginx-prometheus-exporter/blob/main/grafana/README.md)

## Как запустить проект:
 - https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md

## Как проверить работоспособность:
 - Метрики отображаются на дашборде

<img width="2172" alt="Screenshot 2023-09-12 at 19 44 56 2" src="https://github.com/otus-kuber-2023-06/enegu_platform/assets/66974613/1529e061-8e6d-4a24-b4f8-cac3b912c0d2">


## PR checklist:
 - [x] Выставлен label с темой домашнего задания

