### PR TITLE
HW#13. Kubernetes debug

### DIFF
--- a/kubernetes-debug/kit/deploy/cr-nodes.yaml
+++ b/kubernetes-debug/kit/deploy/cr-nodes.yaml
@@ -1,0 +1,7 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"
+spec:
+  serverNode: "minikube"
+  clientNode: "minikube"

--- a/kubernetes-debug/kit/deploy/cr.yaml
+++ b/kubernetes-debug/kit/deploy/cr.yaml
@@ -1,0 +1,4 @@
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/deploy/crd.yaml
+++ b/kubernetes-debug/kit/deploy/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/deploy/operator.yaml
+++ b/kubernetes-debug/kit/deploy/operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/deploy/rbac.yaml
+++ b/kubernetes-debug/kit/deploy/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/kube-iptables-tailer-daemonset-fix.yaml
+++ b/kubernetes-debug/kit/kube-iptables-tailer-daemonset-fix.yaml
@@ -1,0 +1,45 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+              - name: "POD_IDENTIFIER"
+                value: "label"
+              - name: "POD_IDENTIFIER_LABEL"
+                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/kube-iptables-tailer-daemonset.yaml
+++ b/kubernetes-debug/kit/kube-iptables-tailer-daemonset.yaml
@@ -1,0 +1,40 @@
+---
+  apiVersion: "apps/v1"
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec:
+        serviceAccount: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+            env:
+              - name: LOG_LEVEL
+                value: info
+              - name: "IPTABLES_LOG_PATH"
+                value: "/var/log/iptables.log"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal"
+            image: "boxinc/kube-iptables-tailer:v0.1.0"
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log"
+                readOnly: true
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"

--- a/kubernetes-debug/kit/kube-iptables-tailer-sa-cr-crb.yaml
+++ b/kubernetes-debug/kit/kube-iptables-tailer-sa-cr-crb.yaml
@@ -1,0 +1,36 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["v1"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-iptables-tailer
+subjects:
+  - kind: ServiceAccount
+    name: kube-iptables-tailer
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: kube-iptables-tailer
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/netperf-calico-networkpolicy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: projectcalico.org/v3
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: app == "netperf-operator"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/strace/agent_daemonset.yaml
+++ b/kubernetes-debug/strace/agent_daemonset.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:0.0.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate

--- a/kubernetes-debug/strace/agent_daemonset.yaml
+++ b/kubernetes-debug/strace/agent_daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -14,7 +14,7 @@ spec:
         app: debug-agent
     spec:
       containers:
-      - image: aylei/debug-agent:0.0.1
+      - image: aylei/debug-agent:v0.1.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
# Выполнено ДЗ №13

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:

### kubectl debug

Установлен kubectl debug :

	brew install aylei/tap/kubectl-debug

В кластере запущены поды с агентом kubectl-debug.

strace корректно работает с версией агента v0.1.1

### netperf-operator

source: https://github.com/piontec/netperf-operator

В качестве тестового приложения  возьмем netperf-operator. Это Kubernetes-оператор, который позволяет запускать тесты пропускной способности сети между нодами кластера.

Установлены манифесты для запуска оператора в кластере (лежат в папке deploy в репозитории проекта):

- Custom Resource Definition - схема манифестов для запуска тестов
Netperf
- RBAC - политики и разрешения для нашего оператора
- Оператор, который будет следить за появлением ресурсов с Kind: Netperf и запускать поды с клиентом и сервером утилиты NetPerf

Выполнены команды:

	kubectl apply -f ./deploy/crd.yaml
	kubectl apply -f ./deploy/rbac.yaml
	kubectl apply -f ./deploy/operator.yaml

Запущен тест, применив манифест cr.yaml из папки deploy

	kubectl apply -f ./deploy/crd.yaml

Добавлена сетевая политика для Calico, чтобы ограничить доступ к подам Netperf и включить логирование в iptables.

### iptables-tailer to the rescue! 🚒

source: https://github.com/box/kube-iptables-tailer/blob/master/demo/daemonset.yaml

Попытки запустить iptables-tailer используя манифест из репозитория проекта.
Пройден путь правок, в итоге используется daemonset - https://github.com/express42/otus-platform-snippets/tree/master/Module-03/Debugging/iptables-tailer.yaml

Проверка логок одного из созданных подов DaemonSet - контейнеры нормально запустились.

Запуск тестов NetPerf и проверка событий в кластере Kubernetes:

	kubectl get events -A
	kubectl describe pod --selector=app=netperf-operator

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
